### PR TITLE
Fixed regex that parse comments.

### DIFF
--- a/src/main/scala/lomrf/mln/model/KB.scala
+++ b/src/main/scala/lomrf/mln/model/KB.scala
@@ -98,8 +98,8 @@ class KB(val predicateSchema: PredicateSchema,
 
 object KB {
 
-  private lazy val formulaRegex = Pattern.compile(".*\\s=>\\s.*|.*\\s<=>\\s.*|.*\\s:-\\s.*|.*\\s^\\s.*|.*\\sv\\s.*|.*\\s!\\s.*|\\d.*|.*\\.")
-  private lazy val ignoreRegex = Pattern.compile("\\s*\\*.*|/\\*.*|//.*|\\s+")
+  private lazy val formulaRegex = Pattern.compile("^[^(//)](.*\\s=>\\s.*|.*\\s<=>\\s.*|.*\\s:-\\s.*|.*\\s^\\s.*|.*\\sv\\s.*|.*\\s!\\s.*|\\d.*|.*\\.)")
+  private lazy val ignoreRegex = Pattern.compile("(\\s*\\*.*|/\\*.*|//.*|\\s+)+")
   private lazy val log = Logger(this.getClass)
 
   def apply(predicateSchema: PredicateSchema,
@@ -199,7 +199,6 @@ object KB {
     while (fileReader.ready() && !stop) {
       val line = fileReader.readLine()
       lineIdx += 1
-
       if (!line.isEmpty) {
         if (formulaMatcher.reset(line).matches()) stop = true
         else if (!commentMatcher.reset(line).matches()) {


### PR DESCRIPTION
HI.
When using `lomrf compile`, me and  @luca-morreale have discovered a problem concerning how the program deals with comments. On your current implementation, the parser would recognize comments ending with `.` as predicates and, thus, generate an exception that would prevent the code compilation. Below you find a piece of the exception stack:

`Exception in thread "main" java.io.IOException: Stream not marked
        at java.io.BufferedReader.reset(BufferedReader.java:512)
        at lomrf.mln.model.KB$.fromFile(KB.scala:244)
        ...
` 
Best regards.
Thanks.

  